### PR TITLE
[WIP]SkyScannerAPI list_placesの実装

### DIFF
--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -31,13 +31,14 @@
   <br>
 </div>
 <%# <%= @response["Places"] %>
-<%# 次は繰り返しで安い順に出発地、到着地、値段を出力 %>
 
+<p>到着地: <%= @arrival_airport %></p>
+<%# 次は繰り返しで安い順に出発地、到着地、値段を出力 %>
 
 <%= @place %>
 <%= @OriginId_array %>
 <% @indicate_place_array.each do |place| %>
-  <p>出発地: <%= place["Name"] %>     最安値: ¥<%= place["MinPrice"] %></p>
+  <p>出発地: <%= place["Name"] %>     最安値: ¥<%= place["MinPrice"].floor %></p>
 <% end %>
 
 <%# EasyTranslateのAPIが見つからないためAPIkey取得不可 %>


### PR DESCRIPTION
plansテーブルのregionカラムから都市名などを取得してそれを到着地としてAPIを叩く実装
region情報が日本語だった時のためにencodingしてリクエストをapiに送る実装

・この時点で可能になったこと
region(planレコードの開催地情報)が日本語でもアルファベットでも、そこまでの安い航空券候補をリストで取得できるようになった。